### PR TITLE
Move the Qt version from 4 to 5 & Add support for Docker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,28 @@
+cmake_minimum_required(VERSION 3.10)
 project(LabelMaker)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 find_package(OpenCV)
 
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
 if(OpenCV_VERSION VERSION_LESS "4.0")
 else()
     add_definitions(-DCV4)
 endif(OpenCV_VERSION VERSION_LESS)
-find_package(Qt4 REQUIRED)
+find_package(Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
+find_package(QtGui)
 set(QT_USE_QTMAIN true)
 set(QT_USE_QTGUI true)
 set(QT_USE_QTNETWORK true)
 set(QT_USE_QTOPENGL true)
-include(${QT_USE_FILE})
+INCLUDE_DIRECTORIES(${QT_USE_FILE})
 add_definitions(${QT_DEFINITIONS})
 include(labelmaker.cmake)
-QT4_WRAP_UI(LABELMAKER_UIS_H ${LABELMAKER_UIS})
-QT4_WRAP_CPP(LABELMAKER_MOC_SRCS ${LABELMAKER_MOC_HDRS})
+QT5_WRAP_UI(LABELMAKER_UIS_H ${LABELMAKER_UIS})
+QT5_WRAP_CPP(LABELMAKER_MOC_SRCS ${LABELMAKER_MOC_HDRS})
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} src)
 add_executable(LabelMaker
@@ -26,6 +32,7 @@ add_executable(LabelMaker
 )
 
 target_link_libraries(LabelMaker
-	${OpenCV_LIBS}
+	Qt5::Widgets
+  ${OpenCV_LIBS}
 	${QT_LIBRARIES}
 	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ else()
 endif(OpenCV_VERSION VERSION_LESS)
 find_package(Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
-find_package(QtGui)
 set(QT_USE_QTMAIN true)
 set(QT_USE_QTGUI true)
 set(QT_USE_QTNETWORK true)
@@ -33,6 +32,6 @@ add_executable(LabelMaker
 
 target_link_libraries(LabelMaker
 	Qt5::Widgets
-  ${OpenCV_LIBS}
+    ${OpenCV_LIBS}
 	${QT_LIBRARIES}
 	)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:20.04
+
+# Install dependencies.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git \
+    build-essential \
+    cmake \
+    qt5-default  \
+    libglib2.0-0 \
+    libqt5dbus5 \
+    libqt5widgets5 \
+    libqt5network5 \
+    libqt5gui5 \
+    libqt5core5a \
+    libfontconfig1 \
+    mesa-common-dev  \
+    libglu1-mesa-dev \
+    mesa-utils \
+    x11-apps \
+    libopencv-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth=1 -b chanege_to_qt5 https://github.com/Dansato1203/YLLabelMaker.git
+
+WORKDIR /YLLabelMaker
+
+RUN cmake .
+
+RUN make -j8
+
+CMD ["./LabelMaker"]

--- a/launch_labelmaker.sh
+++ b/launch_labelmaker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+DOCKER_IMAGE="labelmaker:latest"
+
+id=${1:-"1"}
+
+gpu="--gpus=all"
+if ! command -v nvidia-smi &> /dev/null
+then
+    echo "NVIDIA Driver not be found"
+    gpu=""
+fi
+
+xhost +
+docker run $gpu -it --rm --privileged \
+    -e DISPLAY=$DISPLAY \
+    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+    -u `id -u`:`id -g` \
+    -e QT_X11_NO_MITSHM=1 \
+    --name labelmaker \
+    --device /dev/dri \
+    -v $PWD/label_image:/YLLabelMaker/label_image:rw \
+    $DOCKER_IMAGE 

--- a/launch_labelmaker.sh
+++ b/launch_labelmaker.sh
@@ -1,22 +1,13 @@
 #!/bin/bash
 DOCKER_IMAGE="labelmaker:latest"
 
-id=${1:-"1"}
-
-gpu="--gpus=all"
-if ! command -v nvidia-smi &> /dev/null
-then
-    echo "NVIDIA Driver not be found"
-    gpu=""
-fi
-
 xhost +
-docker run $gpu -it --rm --privileged \
-    -e DISPLAY=$DISPLAY \
-    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+docker run -it --rm --privileged \
     -u `id -u`:`id -g` \
+    -e DISPLAY=$DISPLAY \
     -e QT_X11_NO_MITSHM=1 \
     --name labelmaker \
     --device /dev/dri \
+    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
     -v $PWD/label_image:/YLLabelMaker/label_image:rw \
     $DOCKER_IMAGE 

--- a/src/MyQView.h
+++ b/src/MyQView.h
@@ -1,7 +1,7 @@
 #ifndef MYQVIEW_H
 #define MYQVIEW_H
 
-#include <QGraphicsView>
+#include <QtWidgets/QGraphicsView>
 #include <QMouseEvent>
 #include <QDebug>
 

--- a/src/MyQView.h
+++ b/src/MyQView.h
@@ -9,7 +9,7 @@ class MyQView :public QGraphicsView
 {
     Q_OBJECT
 public:
-    MyQView(QWidget *parent = 0);
+    MyQView(QWidget *parent = nullptr);
 signals:
     void mouseMoved(int x, int y, Qt::MouseButton button);
     void mousePressed(int x, int y ,Qt::MouseButton button);

--- a/src/MyQclass.cpp
+++ b/src/MyQclass.cpp
@@ -68,11 +68,7 @@ QFileInfoList MyQclass::scanFiles(QString targetpath ,QString filter)
 
 QPixmap MyQclass::MatBGR2pixmap(cv::Mat src)
 {
-#ifdef CV4
     cv::cvtColor(src, src,cv::COLOR_BGR2BGRA);
-#else
-    cv::cvtColor(src, src,CV_BGR2BGRA);
-#endif
     QPixmap pixmap = QPixmap::fromImage(QImage(src.data, src.cols, src.rows, QImage::Format_ARGB32));
     return pixmap;
 }

--- a/src/MyQclass.h
+++ b/src/MyQclass.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <QObject>
-#include <QWidget>
+#include <QtWidgets/QtWidgets>
 #include <QFileInfo>
 #include <QFileDialog>
 #include <QFile>

--- a/src/MyQclass.h
+++ b/src/MyQclass.h
@@ -11,8 +11,8 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <opencv2/opencv.hpp>
-#include <QGraphicsScene>
-#include <QGraphicsSceneMouseEvent>
+#include <QtWidgets/QGraphicsScene>
+#include <QtWidgets/QGraphicsSceneMouseEvent>
 #include <QTime>
 
 enum COLORS

--- a/src/labelmaker.cpp
+++ b/src/labelmaker.cpp
@@ -142,8 +142,8 @@ void LabelMaker::convertAxsisGraphics2CurrentImage(int mx, int my, int *out_mx, 
 	my -= offset;
     int w = scene_img_w;
     int h = scene_img_h;
-    *out_mx = (int)((double)mx / w * currentimg.cols);
-    *out_my = (int)((double)my / h * currentimg.rows);
+    *out_mx = (int)((double)mx / w * currentimg.width());
+    *out_my = (int)((double)my / h * currentimg.height());
 }
 void LabelMaker::searchBboxByMI(int mx, int my, int *out_x1, int *out_y1, int *out_x2, int *out_y2)
 {
@@ -155,7 +155,7 @@ void LabelMaker::searchBboxByMI(int mx, int my, int *out_x1, int *out_y1, int *o
     int max_r = 0;
     double max_mi = 0;
     QPoint maxp;
-	QImage img = QImage(currentimg.data, currentimg.cols,currentimg.rows, QImage::Format_RGB888);
+	QImage img = QImage(currentimg.convertToFormat(QImage::Format_RGB888));
 	int r_min = 30 * ((double)my / img.height());
 	int r_max = 90 * ((double)my / img.height());
 	r_min = (r_min > 10)?r_min:10;
@@ -171,10 +171,10 @@ void LabelMaker::searchBboxByMI(int mx, int my, int *out_x1, int *out_y1, int *o
 		int step = 2;
         for(int x=mx-size; x < mx+size; x+=step)
 		{
-			if(((currentimg.cols - mw) <= x) || (x <= r)) continue;
+			if(((currentimg.width() - mw) <= x) || (x <= r)) continue;
 			for(int y=my-size; y < my+size; y+=step)
 			{
-				if(((currentimg.rows - mh) <= y) || (y <= r) )continue;
+				if(((currentimg.height() - mh) <= y) || (y <= r) )continue;
 				//qDebug() << "r:" << r << QString("(x,y) = (%1,%2)").arg(x).arg(y);
 				double mi = calc_mi(img, ballmask, x-r, y-r);
 				//std::cout << mi << std::endl;
@@ -192,10 +192,10 @@ void LabelMaker::searchBboxByMI(int mx, int my, int *out_x1, int *out_y1, int *o
 		}
     }
     int offset = viewoffset;
-    *out_x1 = (int)((double)(max_x - max_r)/currentimg.cols * scene_img_w)+offset;
-    *out_y1 = (int)((double)(max_y - max_r)/currentimg.rows * scene_img_h)+offset;
-    *out_x2 = (int)((double)(max_x + max_r)/currentimg.cols * scene_img_w)+offset;
-    *out_y2 = (int)((double)(max_y + max_r)/currentimg.rows * scene_img_h)+offset;
+    *out_x1 = (int)((double)(max_x - max_r)/currentimg.width() * scene_img_w)+offset;
+    *out_y1 = (int)((double)(max_y - max_r)/currentimg.height() * scene_img_h)+offset;
+    *out_x2 = (int)((double)(max_x + max_r)/currentimg.width() * scene_img_w)+offset;
+    *out_y2 = (int)((double)(max_y + max_r)/currentimg.height() * scene_img_h)+offset;
 }
 double LabelMaker::calc_mi( const QImage &img, const QImage &maskimg, int x0, int y0 )
 {
@@ -289,7 +289,7 @@ void LabelMaker::onPushChooseImagesDir()
     dialog.setWindowFlags(Qt::WindowStaysOnBottomHint);
     QDir dir = myq.selectDir(QDir(d_ui->lineImageDir->text()));
     d_ui->lineImageDir->setText(dir.path());
-    d_ui->lineSaveTo->setText(dir.path()+"_labels");
+    d_ui->lineSaveTo->setText(dir.path());
     dialog.setWindowFlags(Qt::WindowStaysOnTopHint);
     dialog.show();
 }
@@ -392,7 +392,7 @@ int LabelMaker::updateView()
     {
         return -1;
     }
-    if(currentimg.empty())
+    if(currentimg.isNull())
     {
         qDebug() << "img empty.";
         return -1;
@@ -416,18 +416,18 @@ int LabelMaker::updateView()
     return 0;
 }
 
-int LabelMaker::setImage(cv::Mat img)
+int LabelMaker::setImage(const QImage &img)
 {
     int offset = viewoffset;
     scene_img_w = ui->graphicsView->width()-offset*2;
     scene_img_h = ui->graphicsView->height()-offset*2;
-    QPixmap pix;
     if(scene_img_w<=0 || scene_img_h<=0)
     {
         return -1;
     }
-    cv::resize(img,img,cv::Size(scene_img_w,scene_img_h));
-    pix = myq.MatBGR2pixmap(img);
+    //cv::resize(img,img,cv::Size(scene_img_w,scene_img_h));
+    //pix = myq.MatBGR2pixmap(img);
+    QPixmap pix = QPixmap::fromImage(img.scaled(scene_img_w, scene_img_h));
     QGraphicsPixmapItem *p = scene.addPixmap(pix);
     p->setPos(offset,offset);
     return 0;
@@ -477,7 +477,8 @@ int LabelMaker::drawBbox()
 
 void LabelMaker::loadImage()
 {
-    currentimg = cv::imread(img_list[img_index].filePath().toStdString());
+    //currentimg = cv::imread(img_list[img_index].filePath().toStdString());
+    currentimg = QImage(img_list[img_index].filePath());
 }
 
 void LabelMaker::correctCoordiante(int &x, int &y)
@@ -652,6 +653,7 @@ bool LabelMaker::eventFilter(QObject *obj, QEvent *eve)
 		}
 		return true;
 	}
+    return false;
 }
 
 bool LabelMaker::isPixelInBbox(int x,int y,Bbox *box)

--- a/src/labelmaker.h
+++ b/src/labelmaker.h
@@ -1,7 +1,7 @@
 #ifndef LABELMAKER_H
 #define LABELMAKER_H
 
-#include <QWidget>
+#include <QtWidgets/QtWidgets>
 #include <fstream>
 #include <QGraphicsObject>
 #include <QGraphicsItem>

--- a/src/labelmaker.h
+++ b/src/labelmaker.h
@@ -3,8 +3,8 @@
 
 #include <QtWidgets/QtWidgets>
 #include <fstream>
-#include <QGraphicsObject>
-#include <QGraphicsItem>
+#include <QtWidgets/QGraphicsObject>
+#include <QtWidgets/QGraphicsItem>
 #include <QSettings>
 #include <MyQclass.h>
 #include <ui_dirdialog.h>
@@ -20,7 +20,7 @@ class LabelMaker : public QWidget
     Q_OBJECT
 
 public:
-    explicit LabelMaker(QWidget *parent = 0);
+    explicit LabelMaker(QWidget *parent = nullptr);
     ~LabelMaker();
     struct Cursur
     {
@@ -69,11 +69,13 @@ private:
     QFileInfoList img_list;
     MyQclass myq;
     QGraphicsScene scene;
-    cv::Mat currentimg;
+    //cv::Mat currentimg;
+    QImage currentimg;
     QSettings key;
     void connectSignals();
     int updateView();
-    int setImage(cv::Mat src);
+    //int setImage(cv::Mat src);
+    int setImage(const QImage &img);
     int drawCursur();
     int drawRect();
     int drawBbox();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,9 +3,10 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication a(argc, argv);
-    LabelMaker w;
-    w.showMaximized();
+    QApplication app(argc, argv);
+    LabelMaker *labelmaker = new LabelMaker;
+    
+    labelmaker->showMaximized();
 
-    return a.exec();
+    return app.exec();
 }


### PR DESCRIPTION
## 概要
Qt4からQt5への移行およびDockerでの動作をサポートするようになるPRです。
また、従来から生成するテキストファイルの場所を変更し、画像と同じディレクトリに生成するようにしています。

## 変更点
このPRによる変更点は以下の通りです。
- Qt4からQt5への移行
  - UIへの変更はありません。
- Dockerでの動作をサポート
  - Dockerfileとlaunchファイルを追加しています。使用方法は以下で示します。
- 生成するテキストファイルの場所の変更
  - 生成されるテキストファイルの場所を変更し、画像ファイルと同じ階層に生成されるようになります。 

### Dockerでの使用方法
1. buildします。Tagは任意で構いませんが、変更した際はlaunchファイルも変更してください。
ここではTagを`labelmaker`にしています。
```
docker build -t labelmaker .
```
2. アノテーションしたい画像ファイル郡をlabel_imageディレクトリに入れてください。
  
3. launchファイルを実行することでYLLabelMakerが起動します。
その後の操作は従来通りです。